### PR TITLE
fix (SetRowPreProcessor): SetRowPreProcessor accumulates changes if row variable are not reinitialized each run

### DIFF
--- a/sqltocsv.go
+++ b/sqltocsv.go
@@ -119,9 +119,9 @@ func (c Converter) Write(writer io.Writer) error {
 	count := len(columnNames)
 	values := make([]interface{}, count)
 	valuePtrs := make([]interface{}, count)
-	row := make([]string, count)
 
 	for rows.Next() {
+		row := make([]string, count)
 
 		for i, _ := range columnNames {
 			valuePtrs[i] = &values[i]


### PR DESCRIPTION
Hi there, thanks for your simple and wonderful tool.
This PR fixing situation when you are using tool in following manner:

```			
                        csvConverter := sqltocsv.New(rows)
			headers, _ := rows.Columns()
			csvConverter.Headers = append(headers, "md5sum")
			csvConverter.SetRowPreProcessor(func(cols []string, columnNames []string) (bool, []string) {
				r := strings.Join(cols, "")
				hashed := md5.Sum([]byte(r))
				return true, append(cols, fmt.Sprintf("%x", hashed))
			})
			err := csvConverter.WriteFile(filename)
```

You will get following (debug output):

```
5.63      , 2242bda6e09c8f40f6be686ccd195e60
5.63      2242bda6e09c8f40f6be686ccd195e60, d5072560c4b50d59fe145684aab8d5be
5.63      2242bda6e09c8f40f6be686ccd195e60d5072560c4b50d59fe145684aab8d5be, 7ab73532c59dbe30052cd00cae9f783a
```